### PR TITLE
Create proxy tests

### DIFF
--- a/src/create-proxy.js
+++ b/src/create-proxy.js
@@ -1,0 +1,28 @@
+const httpProxy = require('http-proxy');
+const writeError = require('./write-error');
+
+module.exports = apiKey => {
+  const proxy = httpProxy.createProxyServer({
+    changeOrigin: true,
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    target: 'https://api.airtable.com',
+    secure: false,
+    ssl: {
+      rejectUnauthorized: false,
+    },
+  });
+
+  proxy.on('error', (err, req, res) => {
+    writeError(
+      res,
+      500,
+      'Internal Server Error',
+      `An unknown error occurred: ${err.message}`
+    );
+  });
+
+  return proxy;
+};

--- a/src/create-proxy.test.js
+++ b/src/create-proxy.test.js
@@ -1,0 +1,12 @@
+const createProxy = require('./create-proxy');
+
+describe('createProxy', () => {
+  it('creates proxy server with headers', () => {
+    const apiKey = 'abc123';
+
+    const result = createProxy(apiKey);
+
+    expect(result.options.headers.Authorization).toEqual(`Bearer ${apiKey}`);
+    expect(result.options.headers.Accept).toEqual('application/json');
+  });
+});

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,7 +1,8 @@
 const parse = require('url').parse;
-const httpProxy = require('http-proxy');
 const route = require('path-match')();
 const getConfig = require('./config');
+const createProxy = require('./create-proxy');
+const writeError = require('./write-error');
 
 const ALLOWED_HTTP_HEADERS = [
   'Authorization',
@@ -15,37 +16,6 @@ const ALLOWED_HTTP_HEADERS = [
 ];
 
 const match = route('/:version/*');
-
-const writeError = (res, status, code, message) => {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ code, message }));
-};
-
-const createProxy = apiKey => {
-  const proxy = httpProxy.createProxyServer({
-    changeOrigin: true,
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    target: 'https://api.airtable.com',
-    secure: false,
-    ssl: {
-      rejectUnauthorized: false,
-    },
-  });
-
-  proxy.on('error', (err, req, res) => {
-    writeError(
-      res,
-      500,
-      'Internal Server Error',
-      `An unknown error occurred: ${err.message}`
-    );
-  });
-
-  return proxy;
-};
 
 module.exports = options => {
   const config = getConfig(options);

--- a/src/write-error.js
+++ b/src/write-error.js
@@ -1,0 +1,4 @@
+module.exports = (res, status, code, message) => {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ code, message }));
+};

--- a/src/write-error.test.js
+++ b/src/write-error.test.js
@@ -1,0 +1,29 @@
+const writeError = require('./write-error');
+
+describe('writeError', () => {
+  beforeEach(() => {
+    this.res = {
+      writeHead: () => {},
+      end: () => {},
+    };
+    this.status = 405;
+    this.code = 'Method Not Allowed';
+    this.message = 'This API does not allow "DELETE" requests';
+  });
+
+  it('ends response with error', () => {
+    spyOn(this.res, 'writeHead').and.callThrough();
+    spyOn(this.res, 'end').and.callThrough();
+
+    writeError(this.res, this.status, this.code, this.message);
+
+    expect(this.res.writeHead).toHaveBeenCalledTimes(1);
+    expect(this.res.writeHead).toHaveBeenCalledWith(this.status, {
+      'Content-Type': 'application/json',
+    });
+    expect(this.res.end).toHaveBeenCalledTimes(1);
+    expect(this.res.end).toHaveBeenCalledWith(
+      JSON.stringify({ code: this.code, message: this.message })
+    );
+  });
+});


### PR DESCRIPTION
- Moved `createProxy` and `writeError` functions to their own files
- Added unit tests (albeit very limited) to each

I think as we build more complexity, it's nice to have more of the standalone functions tested and compartmentalized. These tests are very limited at this point since there isn't a ton going on in these functions, but I think it will ensure that as new functionality is built in, we're in the habit of testing it.

Feedback welcome!