### PR TITLE
Add table-specific permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nothing yet.
+
+- Support passing specific permissions per-table ([#18](https://github.com/rosszurowski/micro-airtable-api/pull/18))
 
 ## [1.0.0] - 2018-09-11
 
 ### Added
+
 - npm package.
 
 ### Changed
+
 - Server script to uses package export (`src/handler.js`) internally.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Use Airtable as a cheap-and-easy CMS for simple blogs and sites :tada:
 
 > :construction: This project has not been thoroughly tested. Use at your own risk!
 
-## Setup
+## Usage
 
-There are three ways to run this library and set up your own Airtable proxy:
-
-### Now
-
-To use [`now`](https://now.sh/) and deploy with a single command:
+The simplest way to get started with your own Airtable proxy is via [`now`](https://now.sh/). Setup and deploy with a single command:
 
 ```bash
 $ now rosszurowski/micro-airtable-api -e AIRTABLE_BASE_ID=asdf123 -e AIRTABLE_API_KEY=xyz123
@@ -27,25 +23,25 @@ $ now rosszurowski/micro-airtable-api -e AIRTABLE_BASE_ID=asdf123 -e AIRTABLE_AP
 Once deployed, you can read or edit your data at:
 
 ```
-https://micro-airtable-api-asdasd.now.sh/v0/Table
+https://micro-airtable-api-asdasd.now.sh/v0/TableName
 ```
 
 To update to a new version with potential bugfixes, all you have to do is run the `now` command again and change the URL you call in your app!
 
 ### CLI
 
-Install the package globally and run it:
+If you'd like to run a proxy on a different service, you can use the `micro-airtable-api` command-line. Install the package globally and run it:
 
 ```bash
 $ npm i -g micro-airtable-api
 $ AIRTABLE_BASE_ID=asdf123 AIRTABLE_API_KEY=xyz123 micro-airtable-api
 
-> Starts server on port 3000
+> micro-airtable-api listening on http://localhost:3000
 ```
 
-### JS
+### JS API
 
-Install the package locally and pass the handler into your webserver:
+For more advanced configuration or to integrate with an existing http or express server, you can also install the package locally and pass the handler into your webserver:
 
 ```bash
 $ npm i micro-airtable-api
@@ -71,12 +67,86 @@ Read below for [all configurable options](#configuration).
 
 ## Configuration
 
-`micro-airtable-api` supports a few different options through environment variables for easy deployment.
+`micro-airtable-api` is configurable both through the JS API and the CLI.
 
-- **`AIRTABLE_BASE_ID` (required)** The _Base ID_ of the Airtable you want to connect to. You can find this in your [Airtable API docs](https://airtable.com/api).
-- **`AIRTABLE_API_KEY` (required)** Your personal account API key. You can find this in [your account settings](https://airtable.com/account).
-- `READ_ONLY` A shortcut flag to restrict the API to only `GET` requests. Users of the API will be able to list all records and individual records, but not create, update, or delete.
-- `ALLOWED_METHODS` A comma-separated list of allowed HTTP methods for this API. Use this to restrict how users can interact with your API. For example, allow creating new records but not deleting by passing in a string without the delete method: `ALLOWED_METHODS=GET,POST,PATCH`. The `READ_ONLY` flag is simply a shortcut to `ALLOWED_METHODS=GET`. Note, the `OPTIONS` method is always allowed for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) purposes.
+```jsx
+const http = require('http');
+const createAirtableProxy = require('micro-airtable-api');
+
+const config = {};
+
+http.createServer(createAirtableProxy(config));
+```
+
+#### `config.airtableBaseId` **(required)**
+
+The _Base ID_ of the Airtable you want to connect to. You can find this in your [Airtable API docs](https://airtable.com/api).
+
+#### `config.airtableApiKey` **(required)**
+
+Your personal account API key. You can find this in [your account settings](https://airtable.com/account).
+
+#### `config.allowedMethods`
+
+An array of HTTP methods supported by the API. Use this to restrict how users can interact with your API. Defaults to all methods.
+
+This maps directly to operations on Airtable:
+
+- `GET` allows reading lists of records or individual records
+- `POST` allows creating new records
+- `PATCH` allows updating existing records
+- `DELETE` allows removing records.
+
+To create a read-only API, to use as a CMS:
+
+```jsx
+createAirtableProxy({
+  airtableBaseId: '...',
+  airtableApiKeyId: '...',
+  allowedMethods: ['GET'],
+});
+```
+
+To create a write-only API, to use for collecting survey responses:
+
+```jsx
+// A write-only API (eg. surveys)
+createAirtableProxy({
+  airtableBaseId: '...',
+  airtableApiKeyId: '...',
+  allowedMethods: ['POST'],
+});
+```
+
+You can set table-specific permissions by passing in an object with table names as the keys.
+
+If you were setting up a blog through Airtable, you could do the following:
+
+```jsx
+createAirtableProxy({
+  airtableBaseId: '...',
+  airtableApiKeyId: '...',
+  allowedMethods: {
+    'Blog Posts': ['GET'],
+    'Blog Comments': ['POST', 'PATCH', 'DELETE'],
+  },
+});
+```
+
+Note, the `OPTIONS` method is always allowed for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) purposes.
+
+### CLI Options
+
+The CLI exposes the above configuration options through environment variables for easy deployment.
+
+```bash
+$ AIRTABLE_BASE_ID=asdf123 AIRTABLE_API_KEY=xyz123 micro-airtable-api
+```
+
+- **`AIRTABLE_BASE_ID` (required)** Same as `config.airtableBaseId` above
+- **`AIRTABLE_API_KEY` (required)** Same as `config.airtableApiKey` above
+- `ALLOWED_METHODS` Similar to `config.allowedMethods` above, except a comma-separated list instead of an array. For example, allow creating new records but not deleting by passing in a string without the delete method: `ALLOWED_METHODS=GET,POST,PATCH`.
+- `READ_ONLY` A shortcut variable to restrict the API to only `GET` requests. Equivalent to `ALLOWED_METHODS=GET`. Users of the API will be able to list all records and individual records, but not create, update, or delete.
 - `PORT` Sets the port for the local server. Defaults to `3000`.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $ AIRTABLE_BASE_ID=asdf123 AIRTABLE_API_KEY=xyz123 micro-airtable-api
 
 - **`AIRTABLE_BASE_ID` (required)** Same as `config.airtableBaseId` above
 - **`AIRTABLE_API_KEY` (required)** Same as `config.airtableApiKey` above
-- `ALLOWED_METHODS` Similar to `config.allowedMethods` above, except a comma-separated list instead of an array. For example, allow creating new records but not deleting by passing in a string without the delete method: `ALLOWED_METHODS=GET,POST,PATCH`.
+- `ALLOWED_METHODS` Similar to `config.allowedMethods` above, except a comma-separated list instead of an array. For example, allow creating new records but not deleting by passing in a string without the delete method: `ALLOWED_METHODS=GET,POST,PATCH`. The CLI does not support table-specific permissions. Use the JS API if this is something you need.
 - `READ_ONLY` A shortcut variable to restrict the API to only `GET` requests. Equivalent to `ALLOWED_METHODS=GET`. Users of the API will be able to list all records and individual records, but not create, update, or delete.
 - `PORT` Sets the port for the local server. Defaults to `3000`.
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+const { isObject } = require('./utils');
+
 const invariant = (condition, err) => {
   if (condition) {
     return;
@@ -24,8 +26,8 @@ module.exports = inputConfig => {
     new TypeError('config.airtableBaseId must be a string')
   );
   invariant(
-    Array.isArray(config.allowedMethods),
-    new TypeError('config.allowedMethods must be an array')
+    Array.isArray(config.allowedMethods) || isObject(config.allowedMethods),
+    new TypeError('config.allowedMethods must be an array or object')
   );
 
   return config;

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,9 @@ module.exports = inputConfig => {
     new TypeError('config.airtableBaseId must be a string')
   );
   invariant(
-    Array.isArray(config.allowedMethods) || isObject(config.allowedMethods),
+    Array.isArray(config.allowedMethods) ||
+      isObject(config.allowedMethods) ||
+      config.allowedMethods === '*',
     new TypeError('config.allowedMethods must be an array or object')
   );
 

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -31,6 +31,6 @@ describe('getConfig', () => {
         airtableBaseId: 'YourBaseId',
         allowedMethods: 'GET,POST',
       });
-    }).toThrow(/allowedMethods must be an array/i);
+    }).toThrow(/allowedMethods must be an array or object/i);
   });
 });

--- a/src/handler.js
+++ b/src/handler.js
@@ -50,7 +50,7 @@ const createProxy = apiKey => {
 
 const getTablePermissions = (config, tableName) => {
   if (!tableName) {
-    return ['GET', 'PUT', 'POST', 'PATCH', 'DELETE'];
+    return '*';
   }
 
   const hasRouteSpecificConfig = isObject(config.allowedMethods);

--- a/src/handler.js
+++ b/src/handler.js
@@ -92,7 +92,7 @@ const getAllowedMethods = (config, tableName) => {
 };
 
 const isAllowed = (allowedMethods, method) => {
-  if (Array.isArray(permissions) && permissions.includes(method)) {
+  if (Array.isArray(allowedMethods) && allowedMethods.includes(method)) {
     return true;
   }
 

--- a/src/handler.js
+++ b/src/handler.js
@@ -60,6 +60,18 @@ const getTablePermissions = (config, tableName) => {
     : config.allowedMethods;
 };
 
+const isAllowed = (permissions, method) => {
+  if (permissions === '*') {
+    return true;
+  }
+
+  if (Array.isArray(permissions) && permissions.includes(method)) {
+    return true;
+  }
+
+  return false;
+};
+
 module.exports = options => {
   const config = getConfig(options);
   const proxy = createProxy(config.airtableApiKey);
@@ -107,7 +119,7 @@ module.exports = options => {
       return;
     }
 
-    if (!tablePermissions.includes(method)) {
+    if (!isAllowed(tablePermissions, method)) {
       writeError(
         res,
         405,

--- a/src/handler.js
+++ b/src/handler.js
@@ -86,16 +86,15 @@ module.exports = options => {
     const rest = params[0] || '';
 
     let path = originalPath;
-    let tableName = null;
 
     if (params !== false) {
-      tableName = rest.split('?').shift();
       path = `/${params.version}/${config.airtableBaseId}/${rest}`;
     }
 
-    const tablePermissions = getTablePermissions(config, tableName);
-
     req.url = path;
+
+    const tableName = rest.split('?').shift();
+    const tablePermissions = getTablePermissions(config, tableName);
 
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Request-Method', '*');

--- a/src/handler.js
+++ b/src/handler.js
@@ -53,7 +53,7 @@ const parseUrl = (originalUrl, airtableBaseId) => {
 
   if (params === false) {
     const originalPath = components.path;
-    return { url: originalPath, tableName: false };
+    return { proxyUrl: originalPath, tableName: false };
   }
 
   const proxyUrl =

--- a/src/handler.js
+++ b/src/handler.js
@@ -75,7 +75,6 @@ const isAllowed = (permissions, method) => {
 module.exports = options => {
   const config = getConfig(options);
   const proxy = createProxy(config.airtableApiKey);
-  const hasRouteSpecificConfig = isObject(config.allowedMethods);
 
   return (req, res) => {
     const method =

--- a/src/handler.js
+++ b/src/handler.js
@@ -90,8 +90,7 @@ module.exports = options => {
 
     if (params !== false) {
       tableName = rest.split('?').shift();
-
-      path = '/' + [params.version, config.airtableBaseId, rest].join('/');
+      path = `/${params.version}/${config.airtableBaseId}/${rest}`;
     }
 
     const tablePermissions = getTablePermissions(config, tableName);

--- a/src/handler.js
+++ b/src/handler.js
@@ -91,9 +91,7 @@ module.exports = options => {
     if (params !== false) {
       tableName = rest.split('?').shift();
 
-      path =
-        '/' +
-        [params.version, config.airtableBaseId, params.table + rest].join('/');
+      path = '/' + [params.version, config.airtableBaseId, rest].join('/');
     }
 
     const tablePermissions = getTablePermissions(config, tableName);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,2 +1,4 @@
 exports.isObject = input =>
   Object.prototype.toString.call(input) === '[object Object]';
+
+exports.compact = arr => arr.filter(Boolean);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,2 @@
+exports.isObject = input =>
+  Object.prototype.toString.call(input) === '[object Object]';


### PR DESCRIPTION
This PR adds the ability to pass in permissions on a per-table basis, as per #6. Like so:

```js
const http = require('http');
const createAirtableProxy = require('micro-airtable-api');

const config = {
  airtableApiKey: 'YourApiKey',
  airtableBaseId: 'YourBaseId',
  allowedMethods: {
    'Posts': ['GET', 'PUT'],
    'Comments': '*',
  }
};

http.createServer(createAirtableProxy(config)).listen(3000);
```

This only allows configuring permissions via an array of method names, or the special-cased `'*'` string. In the future, we may provide hooks to customize permissions based on request parameters.