### PR TITLE
Integration tests

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -3,27 +3,29 @@ const got = require('got');
 const listen = require('test-listen');
 const handler = require('./index');
 
-const describeIfEnv = (process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID) ? describe : xdescribe;
+const describeIfEnv =
+  process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID
+    ? describe
+    : xdescribe;
 const baseConfig = {
   airtableBaseId: process.env.AIRTABLE_BASE_ID,
   airtableApiKey: process.env.AIRTABLE_API_KEY,
 };
 
-const getExistingPosts = async (client) => {
-  return (await client.get('/v0/Posts', {json: true})).body;
+const getExistingPosts = async client => {
+  return (await client.get('/v0/Posts')).body.records;
 };
 
 describeIfEnv('micro-airtable-api', () => {
-
   describe('when `allowedMethods="*"`', () => {
-    const config = {...baseConfig, allowedMethods: '*'};
+    const config = { ...baseConfig, allowedMethods: '*' };
     let server;
     let client;
 
     beforeAll(async () => {
       server = http.createServer(handler(config));
       const baseUrl = await listen(server);
-      client = got.extend({ baseUrl });
+      client = got.extend({ baseUrl, json: true });
     });
 
     describe('GET /v0/Posts', () => {
@@ -35,40 +37,34 @@ describeIfEnv('micro-airtable-api', () => {
     describe('POST /v0/Posts', () => {
       it('returns successful response', async () => {
         await client.post('/v0/Posts', {
-          json: true,
-          headers: {'Content-type': 'application/json'},
-          body: {fields: {title: 'Test POST request'}},
+          body: { fields: { title: 'Test POST request' } },
         });
       });
     });
 
     describe('PUT /v0/Posts/:id', () => {
       it('returns successful response', async () => {
-        const post = (await getExistingPosts(client)).records[0];
+        const post = (await getExistingPosts(client))[0];
 
         await client.put(`/v0/Posts/${post.id}`, {
-          json: true,
-          headers: {'Content-type': 'application/json'},
-          body: {fields: {title: 'Test PUT request'}},
+          body: { fields: { title: 'Test PUT request' } },
         });
       });
     });
 
     describe('PATCH /v0/Posts/:id', () => {
       it('returns successful response', async () => {
-        const post = (await getExistingPosts(client)).records[0];
+        const post = (await getExistingPosts(client))[0];
 
         await client.patch(`/v0/Posts/${post.id}`, {
-          json: true,
-          headers: {'Content-type': 'application/json'},
-          body: {fields: {title: 'Test PATCH request'}},
+          body: { fields: { title: 'Test PATCH request' } },
         });
       });
     });
 
     describe('DELETE /v0/Posts/:id', () => {
       it('returns successful response', async () => {
-        const post = (await getExistingPosts(client)).records[0];
+        const post = (await getExistingPosts(client))[0];
 
         await client.delete(`/v0/Posts/${post.id}`);
       });

--- a/index.test.js
+++ b/index.test.js
@@ -28,6 +28,10 @@ describeIfEnv('micro-airtable-api', () => {
       client = got.extend({ baseUrl, json: true });
     });
 
+    afterAll(() => {
+      server.close();
+    });
+
     describe('GET /v0/Posts', () => {
       it('returns successful response', async () => {
         await client.get('/v0/Posts');

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const supertest = require('supertest');
+const handler = require('./src/handler');
+const parseEnv = require('./src/parse-env');
+
+const describeIfEnv = (process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID) ? describe : xdescribe;
+
+describeIfEnv('handler', () => {
+
+  describe('allowedMethods "*"', () => {
+    this.config = parseEnv(process.env);
+    this.config.allowedMethods = '*';
+
+    it('Can make GET request', () => {
+      const server = http.createServer(handler(this.config));
+
+      supertest(server)
+      .get('http://localhost:3000/v0/Posts')
+      .expect(200)
+      .end(function (err, res) {
+        console.log(err ? 'has error' : 'no error');
+        console.log(res);
+      });
+    });
+
+    it('Knows true', () => {
+      expect(true).toBeTruthy();
+    })
+  });
+});

--- a/micro-airtable-api.test.js
+++ b/micro-airtable-api.test.js
@@ -8,24 +8,22 @@ const baseConfig = {
   airtableApiKey: process.env.AIRTABLE_API_KEY,
 };
 
-const getExistingPosts = async () => {
-  const server = http.createServer(handler(baseConfig));
-
+const getExistingPosts = async (server) => {
   return (await supertest(server).get('/v0/Posts')).body;
 };
 
 describeIfEnv('integration', () => {
-  let config;
 
   describe('allowedMethods "*"', () => {
+    let server;
 
     beforeEach(() => {
-      config = {...baseConfig, allowedMethods: '*'};
-      this.server = http.createServer(handler(config));
+      const config = {...baseConfig, allowedMethods: '*'};
+      server = http.createServer(handler(config));
     });
 
     it('Can make GET request', async () => {
-      this.response = await supertest(this.server)
+      this.response = await supertest(server)
         .get('/v0/Posts');
 
       expect(this.response.statusCode).toBe(200);
@@ -33,7 +31,7 @@ describeIfEnv('integration', () => {
     });
 
     it('Can make POST request', async () => {
-      this.response = await supertest(this.server)
+      this.response = await supertest(server)
         .post('/v0/Posts')
         .send({fields: {title: 'Test POST request'}});
 
@@ -42,9 +40,9 @@ describeIfEnv('integration', () => {
     });
 
     it('Can make PUT request', async () => {
-      const post = (await getExistingPosts()).records[0];
+      const post = (await getExistingPosts(server)).records[0];
 
-      this.response = await supertest(this.server)
+      this.response = await supertest(server)
         .put(`/v0/Posts/${post.id}`)
         .send({fields: {title: 'Test PUT request'}});
 
@@ -53,9 +51,9 @@ describeIfEnv('integration', () => {
     });
 
     it('Can make PATCH request', async () => {
-      const post = (await getExistingPosts()).records[0];
+      const post = (await getExistingPosts(server)).records[0];
 
-      this.response = await supertest(this.server)
+      this.response = await supertest(server)
       .patch(`/v0/Posts/${post.id}`)
       .send({fields: {title: 'Test PATCH request'}});
 
@@ -64,9 +62,9 @@ describeIfEnv('integration', () => {
     });
 
     it('Can make DELETE request', async () => {
-      const post = (await getExistingPosts()).records[0];
+      const post = (await getExistingPosts(server)).records[0];
 
-      this.response = await supertest(this.server)
+      this.response = await supertest(server)
       .delete(`/v0/Posts/${post.id}`);
 
       expect(this.response.statusCode).toBe(200);

--- a/micro-airtable-api.test.js
+++ b/micro-airtable-api.test.js
@@ -12,9 +12,9 @@ const getExistingPosts = async (server) => {
   return (await supertest(server).get('/v0/Posts')).body;
 };
 
-describeIfEnv('integration', () => {
+describeIfEnv('micro-airtable-api', () => {
 
-  describe('allowedMethods "*"', () => {
+  describe('when `allowedMethods="*"`', () => {
     let server;
 
     beforeEach(() => {
@@ -22,53 +22,69 @@ describeIfEnv('integration', () => {
       server = http.createServer(handler(config));
     });
 
-    it('Can make GET request', async () => {
-      this.response = await supertest(server)
-        .get('/v0/Posts');
+    describe('GET /v0/Posts', () => {
+      let response;
 
-      expect(this.response.statusCode).toBe(200);
-      expect(this.response.body).toBeTruthy();
+      beforeEach(async () => {
+        response = await supertest(server).get('/v0/Posts');
+      });
+
+      it('returns successful response', () => expect(response.statusCode).toBe(200));
+      it('contains a response body', () => expect(response.body).toBeTruthy());
     });
 
-    it('Can make POST request', async () => {
-      this.response = await supertest(server)
-        .post('/v0/Posts')
-        .send({fields: {title: 'Test POST request'}});
+    describe('POST /v0/Posts', () => {
+      let response;
 
-      expect(this.response.statusCode).toBe(200);
-      expect(this.response.body).toBeTruthy();
+      beforeEach(async () => {
+        response = await supertest(server)
+          .post('/v0/Posts')
+          .send({fields: {title: 'Test POST request'}});
+      });
+
+      it('returns successful response', () => expect(response.statusCode).toBe(200));
+      it('contains a response body', () => expect(response.body).toBeTruthy());
     });
 
-    it('Can make PUT request', async () => {
-      const post = (await getExistingPosts(server)).records[0];
+    describe('PUT /v0/Posts/:id', () => {
+      let response;
 
-      this.response = await supertest(server)
-        .put(`/v0/Posts/${post.id}`)
-        .send({fields: {title: 'Test PUT request'}});
+      beforeEach(async () => {
+        const post = (await getExistingPosts(server)).records[0];
+        response = await supertest(server)
+          .put(`/v0/Posts/${post.id}`)
+          .send({fields: {title: 'Test PUT request'}});
+      });
 
-      expect(this.response.statusCode).toBe(200);
-      expect(this.response.body).toBeTruthy();
+      it('returns successful response', () => expect(response.statusCode).toBe(200));
+      it('contains a response body', () => expect(response.body).toBeTruthy());
     });
 
-    it('Can make PATCH request', async () => {
-      const post = (await getExistingPosts(server)).records[0];
+    describe('PATCH /v0/Posts/:id', () => {
+      let response;
 
-      this.response = await supertest(server)
-      .patch(`/v0/Posts/${post.id}`)
-      .send({fields: {title: 'Test PATCH request'}});
+      beforeEach(async () => {
+        const post = (await getExistingPosts(server)).records[0];
+        response = await supertest(server)
+          .patch(`/v0/Posts/${post.id}`)
+          .send({fields: {title: 'Test PATCH request'}});
+      });
 
-      expect(this.response.statusCode).toBe(200);
-      expect(this.response.body).toBeTruthy();
+      it('returns successful response', () => expect(response.statusCode).toBe(200));
+      it('contains a response body', () => expect(response.body).toBeTruthy());
     });
 
-    it('Can make DELETE request', async () => {
-      const post = (await getExistingPosts(server)).records[0];
+    describe('DELETE /v0/Posts/:id', () => {
+      let response;
 
-      this.response = await supertest(server)
-      .delete(`/v0/Posts/${post.id}`);
+      beforeEach(async () => {
+        const post = (await getExistingPosts(server)).records[0];
+        response = await supertest(server).delete(`/v0/Posts/${post.id}`);
+      });
 
-      expect(this.response.statusCode).toBe(200);
-      expect(this.response.body).toBeTruthy();
+
+      it('returns successful response', () => expect(response.statusCode).toBe(200));
+      it('contains a response body', () => expect(response.body).toBeTruthy());
     });
   });
 });

--- a/micro-airtable-api.test.js
+++ b/micro-airtable-api.test.js
@@ -1,25 +1,27 @@
 const http = require('http');
 const supertest = require('supertest');
-const handler = require('./src/handler');
-const parseEnv = require('./src/parse-env');
+const handler = require('./index');
 
 const describeIfEnv = (process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID) ? describe : xdescribe;
+const baseConfig = {
+  airtableBaseId: process.env.AIRTABLE_BASE_ID,
+  airtableApiKey: process.env.AIRTABLE_API_KEY,
+};
 
 const getExistingPosts = async () => {
-  const config = parseEnv(process.env);
-  const server = http.createServer(handler(config));
+  const server = http.createServer(handler(baseConfig));
 
   return (await supertest(server).get('/v0/Posts')).body;
 };
 
 describeIfEnv('integration', () => {
-  this.config = parseEnv(process.env);
+  let config;
 
   describe('allowedMethods "*"', () => {
 
     beforeEach(() => {
-      this.config.allowedMethods = '*';
-      this.server = http.createServer(handler(this.config));
+      config = {...baseConfig, allowedMethods: '*'};
+      this.server = http.createServer(handler(config));
     });
 
     it('Can make GET request', async () => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dotenv": "^4.0.0",
     "jest": "^23.5.0",
     "nodemon": "^1.18.3",
-    "prettier": "1.14.2"
+    "prettier": "1.14.2",
+    "supertest": "^3.3.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node bin/index.js",
     "dev": "nodemon -r dotenv/config --ignore '*.test.js' bin/index.js",
-    "prettier": "prettier --write 'index.js' 'src/*.js'",
+    "prettier": "prettier --write 'index.js' 'index.test.js' 'src/*.js'",
     "lint": "prettier --list-different 'index.js' 'src/*.js'",
     "test": "npm run lint --silent && jest"
   },

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
   },
   "devDependencies": {
     "dotenv": "^4.0.0",
+    "got": "^9.2.2",
     "jest": "^23.5.0",
     "nodemon": "^1.18.3",
     "prettier": "1.14.2",
-    "supertest": "^3.3.0"
+    "test-listen": "^1.1.0"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
This is not ready to merge, but I wanted to open conversation on a proof of concept for how we might set up integration tests (re: #17).

TBH, I've never used Supertest or done much integration testing like this in JS before, but it seems to work. I'm very open to feedback on best practices or cleaning it up though!

I just added you as a collaborator on [this airtable base](https://airtable.com/tblcWfadZbQsxW4ay/viwfqecWYF6nsnQmT), so you should be able to run the integration tests via the command line:

```
AIRTABLE_API_KEY=... AIRTABLE_BASE_ID=... npm test
```

If you leave out the API keys, it should skip the integration test suite file.

I'm excited about this, should make debugging easier and regressions less likely! 🎆 